### PR TITLE
Adds js entry and some handy npm scripts

### DIFF
--- a/bsconfig.json
+++ b/bsconfig.json
@@ -8,5 +8,8 @@
   },{
     "kind": "native",
     "main": "Index"
+  },{
+    "kind": "js",
+    "main": "Index"
   }]
 }

--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@
     <title>ReGl Example Project</title>
   </head>
   <body>
-    <script src="lib/js/src/app.js"></script>
+    <script src="bundle.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,6 @@
     <title>ReGl Example Project</title>
   </head>
   <body>
-    <script src="bundle.js"></script>
+    <script src="./require_polyfill.js" data-main="./lib/js/src/index.js" data-project-root="./"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,8 +3,20 @@
   "version": "0.1.0",
   "description": "Simple example project for Reasongl",
   "scripts": {
-    "start": "./lib/bs/index.byte",
-    "build": "bsb -make-world"
+    "build": "run-s 'build:*'",
+    "build:byte": "./node_modules/.bin/bsb -make-world -backend bytecode",
+    "build:native": "./node_modules/.bin/bsb -make-world -backend native",
+    "build:js": "./node_modules/.bin/bsb -make-world -backend js",
+    "clean": "./node_modules/.bin/bsb -clean-world",
+    "dev": "run-p -r 'dev:*'",
+    "dev:byte": "run-s build:byte start:byte",
+    "dev:native": "run-s build:native start:native",
+    "dev:js": "run-p -r 'build:js -- -w' start:js",
+    "start": "run-p -r 'start:*'",
+    "start:byte": "./lib/bs/bytecode/index.byte",
+    "start:native": "./lib/bs/native/index.native",
+    "start:js": "webpack-dev-server ./lib/js/src/index.js",
+    "watch": "run-p -r 'build:* -- -w'"
   },
   "dependencies": {
     "ReasonglInterface": "bsansouci/reasongl-interface#bsb-support-new",
@@ -17,6 +29,9 @@
   },
   "author": "bsansouci & schmavery",
   "devDependencies": {
-    "bsb-native": "bsansouci/bsb-native"
+    "bsb-native": "bsansouci/bsb-native",
+    "npm-run-all": "^4.0.2",
+    "webpack": "^3.5.4",
+    "webpack-dev-server": "^2.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,20 +3,14 @@
   "version": "0.1.0",
   "description": "Simple example project for Reasongl",
   "scripts": {
-    "build": "run-s 'build:*'",
-    "build:byte": "./node_modules/.bin/bsb -make-world -backend bytecode",
-    "build:native": "./node_modules/.bin/bsb -make-world -backend native",
-    "build:js": "./node_modules/.bin/bsb -make-world -backend js",
-    "clean": "./node_modules/.bin/bsb -clean-world",
-    "dev": "run-p -r 'dev:*'",
-    "dev:byte": "run-s build:byte start:byte",
-    "dev:native": "run-s build:native start:native",
-    "dev:js": "run-p -r 'build:js -- -w' start:js",
-    "start": "run-p -r 'start:*'",
+    "build:byte": "bsb -make-world -backend bytecode",
+    "build:native": "bsb -make-world -backend native",
+    "build:js": "bsb -make-world -backend js",
+    "clean": "bsb -clean-world",
     "start:byte": "./lib/bs/bytecode/index.byte",
     "start:native": "./lib/bs/native/index.native",
-    "start:js": "webpack-dev-server ./lib/js/src/index.js",
-    "watch": "run-p -r 'build:* -- -w'"
+    "start:js": "open -a safari index.html",
+    "watch:js": "bsb -make-world -backend js -w"
   },
   "dependencies": {
     "ReasonglInterface": "bsansouci/reasongl-interface#bsb-support-new",
@@ -29,9 +23,6 @@
   },
   "author": "bsansouci & schmavery",
   "devDependencies": {
-    "bsb-native": "bsansouci/bsb-native",
-    "npm-run-all": "^4.0.2",
-    "webpack": "^3.5.4",
-    "webpack-dev-server": "^2.7.1"
+    "bsb-native": "bsansouci/bsb-native"
   }
 }

--- a/require_polyfill.js
+++ b/require_polyfill.js
@@ -1,0 +1,132 @@
+function normalizeArray(parts, allowAboveRoot) {
+  // if the path tries to go above the root, `up` ends up > 0
+  var up = 0;
+  for (var i = parts.length - 1; i >= 0; i--) {
+    var last = parts[i];
+    if (last === '.') {
+      parts.splice(i, 1);
+    } else if (last === '..') {
+      parts.splice(i, 1);
+      up++;
+    } else if (up) {
+      parts.splice(i, 1);
+      up--;
+    }
+  }
+
+  // if the path is allowed to go above the root, restore leading ..s
+  if (allowAboveRoot) {
+    for (; up--; up) {
+      parts.unshift('..');
+    }
+  }
+
+  return parts;
+};
+
+function pathNormalize(path) {
+  var isAbsolute = path.charAt(0) === '/';
+  var trailingSlash = path.substr(-1) === '/';
+
+  // Normalize the path
+  path = normalizeArray(path.split('/').filter(function(p) {
+    return !!p;
+  }), !isAbsolute).join('/');
+
+  if (!path && !isAbsolute) {
+    path = '.';
+  }
+  if (path && trailingSlash) {
+    path += '/';
+  }
+
+  return (isAbsolute ? '/' : '') + path;
+};
+
+var globalEval = eval;
+var currentScript = document.currentScript;
+var projectRoot = currentScript.dataset['project-root'] || currentScript.dataset['projectRoot'];
+if (projectRoot == null) {
+  throw new Error('The attribute `data-project-root` isn\'t found in the script tag. You need to provide the root (in which node_modules reside).')
+}
+var nodeModulesDir = projectRoot + '/node_modules/';
+
+var modulesCache = {};
+var packageJsonMainCache = {};
+
+var ensureEndsWithJs = function(path) {
+  if (path.endsWith('.js')) {
+    return path;
+  } else {
+    return path + '.js';
+  }
+};
+function loadScript(scriptPath) {
+  var request = new XMLHttpRequest();
+
+  request.open("GET", scriptPath, false); // sync
+  request.send();
+  var dirSeparatorIndex = scriptPath.lastIndexOf('/');
+  var dir = dirSeparatorIndex === -1 ? '.' : scriptPath.slice(0, dirSeparatorIndex);
+
+  var moduleText = `
+(function(module, exports, modulesCache, packageJsonMainCache, nodeModulesDir) {
+  function require(path) {
+    var __dirname = "${dir}/";
+    var resolvedPath;
+    if (path.startsWith('.')) {
+      // require('./foo/bar')
+      resolvedPath = ensureEndsWithJs(__dirname + path);
+    } else if (path.indexOf('/') === -1) {
+      // require('react')
+      var packageJson = pathNormalize(nodeModulesDir + path + '/package.json');
+      if (packageJsonMainCache[packageJson] == null) {
+        var jsonRequest = new XMLHttpRequest();
+        jsonRequest.open("GET", packageJson, false);
+        jsonRequest.send();
+        var main;
+        if (jsonRequest.responseText != null) {
+          main = JSON.parse(jsonRequest.responseText).main;
+        };
+        if (main == null) {
+          main = 'index.js';
+        } else if (!main.endsWith('.js')) {
+          main = main + '.js';
+        }
+        packageJsonMainCache[packageJson] = nodeModulesDir + path + '/' + main;
+      }
+      resolvedPath = packageJsonMainCache[packageJson];
+    } else {
+      // require('react/bar')
+      resolvedPath = ensureEndsWithJs(nodeModulesDir + path);
+    };
+    resolvedPath = pathNormalize(resolvedPath);
+    if (modulesCache[resolvedPath] != null) {
+      return modulesCache[resolvedPath];
+    };
+
+    // initialize cache with an empty object, allows circular dependencies
+    modulesCache[resolvedPath] = {};
+    var result = loadScript(resolvedPath);
+    modulesCache[resolvedPath] = result;
+    return result;
+  };
+  var process = {env: {}, argv: []};
+  var global = {};
+
+
+// -------Begin Require Polyfilled Module Loaded From Disk------------------------------
+// file: ${scriptPath}
+// root: ${projectRoot}
+// ----------------------------------------------------------------------
+${request.responseText}
+// -------End Polyfill Loaded From Disk------------------------------
+// file: ${scriptPath}
+// root: ${projectRoot}
+// ----------------------------------------------------------------------
+return module.exports})\n//@ sourceURL=${scriptPath}`;
+  var module = {exports: {}};
+  return globalEval(moduleText)(module, module.exports, modulesCache, packageJsonMainCache, nodeModulesDir);
+};
+
+loadScript(currentScript.dataset.main)


### PR DESCRIPTION
Made it a little easier to test out the repo with the addition of a "few" npm scripts. 
`npm run dev` builds and runs all targets/entries.

Also added JS entry with support for reloading upon change.

